### PR TITLE
update/module v1.4.0

### DIFF
--- a/cluster/resources.tf
+++ b/cluster/resources.tf
@@ -5,7 +5,7 @@ resource "macaddress" "master_net0_mac" {
 module "master_instances" {
   count = local.master_count
 
-  source = "github.com/glitchcrab/terraform-module-proxmox-instance?ref=v1.3.0"
+  source = "github.com/glitchcrab/terraform-module-proxmox-instance?ref=v1.4.0"
 
   pve_instance_name        = "master${count.index}-${local.name_stub}"
   pve_instance_description = "kubernetes managment cluster master"
@@ -42,7 +42,7 @@ resource "macaddress" "worker_net0_mac" {
 module "worker_instances" {
   count = local.worker_count
 
-  source = "github.com/glitchcrab/terraform-module-proxmox-instance?ref=v1.3.0"
+  source = "github.com/glitchcrab/terraform-module-proxmox-instance?ref=v1.4.0"
 
   pve_instance_name        = "worker${count.index}-${local.name_stub}"
   pve_instance_description = "kubernetes managment cluster worker"

--- a/cluster/resources.tf
+++ b/cluster/resources.tf
@@ -11,8 +11,11 @@ module "master_instances" {
   pve_instance_description = "kubernetes managment cluster master"
   vmid                     = local.vmid_base + count.index + local.vmid_offset_master
 
-  target_node   = element(local.host_list, count.index)
+  target_node   = lookup(local.host_list[count.index], "name")
   resource_pool = var.resource_pool
+
+  hastate = local.hastate
+  hagroup = lookup(local.host_list[count.index], "hagroup")
 
   pxe_boot = true
 
@@ -48,8 +51,11 @@ module "worker_instances" {
   pve_instance_description = "kubernetes managment cluster worker"
   vmid                     = local.vmid_base + local.vmid_offset_master + 1 + count.index
 
-  target_node   = element(local.host_list, count.index)
+  target_node   = lookup(local.host_list[count.index], "name")
   resource_pool = var.resource_pool
+
+  hastate = local.hastate
+  hagroup = lookup(local.host_list[count.index], "hagroup")
 
   pxe_boot = true
 

--- a/cluster/resources.tf
+++ b/cluster/resources.tf
@@ -8,7 +8,7 @@ module "master_instances" {
   source = "github.com/glitchcrab/terraform-module-proxmox-instance?ref=v1.4.0"
 
   pve_instance_name        = "master${count.index}-${local.name_stub}"
-  pve_instance_description = "kubernetes managment cluster master"
+  pve_instance_description = local.master_description
   vmid                     = local.vmid_base + count.index + local.vmid_offset_master
 
   target_node   = lookup(local.host_list[count.index], "name")
@@ -48,7 +48,7 @@ module "worker_instances" {
   source = "github.com/glitchcrab/terraform-module-proxmox-instance?ref=v1.4.0"
 
   pve_instance_name        = "worker${count.index}-${local.name_stub}"
-  pve_instance_description = "kubernetes managment cluster worker"
+  pve_instance_description = local.worker_description
   vmid                     = local.vmid_base + local.vmid_offset_master + 1 + count.index
 
   target_node   = lookup(local.host_list[count.index], "name")

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -103,6 +103,6 @@ variable "resource_memory" {
 
 variable "boot" {
   type        = string
-  default     = "order=net0,scsi0"
+  default     = "order=net0;scsi0"
   description = "Boot device order."
 }

--- a/cluster/zz_locals.tf
+++ b/cluster/zz_locals.tf
@@ -1,6 +1,6 @@
 locals {
   hastate            = "enabled"
-  master_count       = 1
+  master_count       = 0
   master_description = "kubernetes management cluster master"
   name_stub          = "room101-a7d-mc"
   vmid_base          = 400

--- a/cluster/zz_locals.tf
+++ b/cluster/zz_locals.tf
@@ -1,11 +1,27 @@
 locals {
-  master_count       = 0
+  hastate            = "enabled"
+  master_count       = 1
+  master_description = "kubernetes management cluster master"
   name_stub          = "room101-a7d-mc"
   vmid_base          = 400
   vmid_offset_master = 10
   worker_count       = 0
+  worker_description = "kubernetes managment cluster worker"
 
-  host_list = ["host-01", "host-02", "host-03"]
+  host_list = [
+    {
+      name    = "host-01"
+      hagroup = "ha-group-1"
+    },
+    {
+      name    = "host-02"
+      hagroup = "ha-group-2"
+    },
+    {
+      name    = "host-03"
+      hagroup = "ha-group-3"
+    }
+  ]
 
   pm_host_address = data.vault_generic_secret.terraform_generic.data["host"]
 }

--- a/cluster/zz_versions.tf
+++ b/cluster/zz_versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     proxmox = {
       source  = "Telmate/proxmox"
-      version = "~> 2.9.0"
+      version = "2.9.10"
     }
     vault = {
       source  = "hashicorp/vault"


### PR DESCRIPTION
- bump terraform module to 1.4.0
- migrate VM placement to use hagroups
- variablise instance descriptions
- correct boot order syntax
- convert host list to use hagroups for VM placement
- pin proxmox provider to avoid bug introduced in 2.9.13
